### PR TITLE
Actualizar dependencias Angular en el frontend

### DIFF
--- a/GestionEventosDeportivosFrontend/package.json
+++ b/GestionEventosDeportivosFrontend/package.json
@@ -1,13 +1,31 @@
 {
+  "scripts": {
+    "ng": "ng",
+    "start": "ng serve",
+    "build": "ng build",
+    "test": "ng test",
+    "lint": "ng lint"
+  },
   "dependencies": {
     "@angular/animations": "^20.3.1",
     "@angular/cdk": "^20.2.4",
+    "@angular/common": "^20.3.1",
+    "@angular/compiler": "^20.3.1",
+    "@angular/core": "^20.3.1",
+    "@angular/forms": "^20.3.1",
     "@angular/material": "^20.2.4",
+    "@angular/platform-browser": "^20.3.1",
+    "@angular/platform-browser-dynamic": "^20.3.1",
     "@angular/router": "^20.3.1",
     "bootstrap": "^5.3.8",
+    "rxjs": "^7.8.1",
+    "tslib": "^2.6.2",
     "zone.js": "^0.15.1"
   },
   "devDependencies": {
-    "@angular-devkit/build-angular": "^20.3.2"
+    "@angular-devkit/build-angular": "^20.3.2",
+    "@angular/cli": "^20.3.2",
+    "@types/node": "^18.19.43",
+    "typescript": "~5.5.4"
   }
 }


### PR DESCRIPTION
## Summary
- incluir los paquetes básicos de Angular y librerías de soporte en `package.json`
- añadir las herramientas de desarrollo de Angular CLI, TypeScript y tipos de Node como dependencias de desarrollo
- definir los scripts de npm habituales (`start`, `build`, `test`, `lint`) que ejecutan el CLI

## Testing
- `npm install` *(falla: 403 Forbidden al descargar `@angular/cli` desde el registry configurado)*
- `npm run build` *(no ejecutado: la instalación de dependencias no pudo completarse)*

------
https://chatgpt.com/codex/tasks/task_e_68cd6e3afab4832fb88a12bea7599b8c